### PR TITLE
solve AttributeError in latest networkx

### DIFF
--- a/internet_3D_visualizer.py
+++ b/internet_3D_visualizer.py
@@ -28,7 +28,7 @@ for file in os.listdir(op.join(path_app, 'dataset')):
         graph = nx.read_gml(op.join(path_graphs, file))
     except nx.exception.NetworkXError:
         continue
-    for name, properties in graph.node.items():
+    for name, properties in graph.nodes.items():
         try:
             point = kml.newpoint(name=name)
             coords = [(


### PR DESCRIPTION
In recent versions of networkx, the correct way to access nodes and their attributes is through the 'nodes' attribute, not 'node'